### PR TITLE
Add %% (escape) token to greeter

### DIFF
--- a/plugins/greeter.py
+++ b/plugins/greeter.py
@@ -1,7 +1,10 @@
 import connection
 import user_data
+import os
 
 welcome_msgs = {}
+
+obfuscated_escape = os.urandom(16).encode('hex')
 
 def afk_token(parsed_input):
     afks = ""
@@ -11,13 +14,15 @@ def afk_token(parsed_input):
 
     return afks
 
-special_tokens = {
-    "%afk%" : afk_token,
-}
+special_tokens = [
+    ("%%", (lambda _: obfuscated_escape)),
+    ("%afk%", afk_token),
+    (obfuscated_escape, (lambda _: "%")),
+]
 
 def render_welcome_msg(parsed_input):
     msg = welcome_msgs[parsed_input["name"]]
-    for old, new_func in special_tokens.iteritems():
+    for old, new_func in special_tokens:
         msg = msg.replace(old, new_func(parsed_input))
     return msg
 


### PR DESCRIPTION
You can use %% to create a % that will not be replaced by other tokens. I used a small hack for this, a 16 bit hexadecimal random value that is generated at startup which serves as a placeholder that won't be replaced by other tokens. After all of them have been applied, the placeholder is converted back to the actual %. I had to use a list instead of a dict for this, because the dict does not provide a predictable order of the elements. (I used it as if it was a list anyways :smile:)
