### PR TITLE
Encode sent strings correctly

### DIFF
--- a/pybot/irc.py
+++ b/pybot/irc.py
@@ -177,7 +177,7 @@ class Irc_server ( threading.Thread ):
             raise ValueError ( "Error: event is not an Irc_event" )
 
         try:
-            self._socket.send ( "%s\r\n" % event.signal )
+            self._socket.send ( "%s\r\n" % event.signal.encode ( "utf-8" ) )
 
         except socket.error:
             pass


### PR DESCRIPTION
I encountered this when I played with the `urlpreview` plugin, making it html-decode titles before sending them. The resulting strings sometimes lead to a crash.