### PR TITLE
Send strings unencoded when encoding fails

### DIFF
--- a/pybot/irc.py
+++ b/pybot/irc.py
@@ -177,7 +177,10 @@ class Irc_server ( threading.Thread ):
             raise ValueError ( "Error: event is not an Irc_event" )
 
         try:
-            self._socket.send ( "%s\r\n" % event.signal.encode ( "utf-8" ) )
+            try:
+                self._socket.send ( "%s\r\n" % event.signal.encode ( "utf-8" ) )
+            except (UnicodeEncodeError, UnicodeDecodeError):
+                self._socket.send ( "%s\r\n" % event.signal )
 
         except socket.error:
             pass


### PR DESCRIPTION
Should this be refactored (By pulling out the text to be sent into a variable), or is this ok?